### PR TITLE
return the result of the Closure executed

### DIFF
--- a/src/AwsCognitoIdentityGuard.php
+++ b/src/AwsCognitoIdentityGuard.php
@@ -476,7 +476,7 @@ class AwsCognitoIdentityGuard implements StatefulGuard
         } elseif ($handler == AWS_COGNITO_AUTH_RETURN_ATTEMPT) {
             return $response;
         } elseif ($handler instanceof Closure) {
-            $handler(new AuthAttemptException($response));
+            return $handler(new AuthAttemptException($response));
         }
 
         return false;


### PR DESCRIPTION
return the result of the Closure executed - allows the closure to re-attempt authentication and return true upon success.