### PR TITLE
Laravel 5.7 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   "require": {
     "php": ">= 5.6.4",
     "aws/aws-sdk-php-laravel": "^3.1",
-    "nesbot/carbon": "~1.20"
+    "nesbot/carbon": "~1.20",
+    "laravel/framework": "^5.7.0"
   },
   "autoload": {
     "psr-0": {

--- a/src/AwsCognitoIdentityGuard.php
+++ b/src/AwsCognitoIdentityGuard.php
@@ -690,7 +690,7 @@ class AwsCognitoIdentityGuard implements StatefulGuard
         // so any further processing can be done. This allows the developer to be
         // listening for anytime a user signs out of this application manually.
         if (isset($this->events)) {
-            $this->events->dispatch(new Logout($user));
+            $this->events->dispatch(new Logout($this->name, $user));
         }
 
         // Once we have fired the logout event we will clear the users out of memory
@@ -770,7 +770,7 @@ class AwsCognitoIdentityGuard implements StatefulGuard
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Attempting(
-                $credentials, $remember
+                $this->name, $credentials, $remember
             ));
         }
     }
@@ -784,7 +784,7 @@ class AwsCognitoIdentityGuard implements StatefulGuard
     protected function fireLoginEvent($user, $remember = false)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Login($user, $remember));
+            $this->events->dispatch(new Login($this->name, $user, $remember));
         }
     }
 
@@ -796,7 +796,7 @@ class AwsCognitoIdentityGuard implements StatefulGuard
     protected function fireAuthenticatedEvent($user)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Authenticated($user));
+            $this->events->dispatch(new Authenticated($this->name, $user));
         }
     }
 
@@ -809,7 +809,7 @@ class AwsCognitoIdentityGuard implements StatefulGuard
     protected function fireFailedEvent($user, array $credentials)
     {
         if (isset($this->events)) {
-            $this->events->dispatch(new Failed($user, $credentials));
+            $this->events->dispatch(new Failed($this->name, $user, $credentials));
         }
     }
 


### PR DESCRIPTION
As of the release of Laravel 5.7 the auth events must be passed the guard name.

This was added here: https://github.com/laravel/framework/commit/69cddedae349956c5f38455e861e3fc490d89a07 and the order of the arguments was changed in a later commit (https://github.com/laravel/framework/commit/f5d8c0a673aa9fc6cd94aa4858a0027fe550a22e).

I have added a requirement of upwards of `laravel/framework` 5.7 to the Composer JSON though I don't know how you want to handle tagging a change like this as it's technically a breaking change