### PR TITLE
Corrects return type in the getResponse docblock

### DIFF
--- a/src/AuthAttemptException.php
+++ b/src/AuthAttemptException.php
@@ -24,7 +24,7 @@ class AuthAttemptException extends RuntimeException
     }
 
     /**
-     * @return \Pallant\LaravelAwsCognitoAuth\AuthAttempt
+     * @return array|null
      */
     public function getResponse()
     {


### PR DESCRIPTION
The doc block for the `getResponse` method was incorrectly declaring the return type